### PR TITLE
Correct package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Require this package, with [Composer](https://getcomposer.org/), in the root directory of your project.
 
 ``` bash
-$ composer require faustbrian/bittrex
+$ composer require faustbrian/bittrex-php-client
 ```
 
 ## Usage


### PR DESCRIPTION
→ composer require faustbrian/bittrex
                                                                                                                                                     
  [InvalidArgumentException]                                                                                                                          
  Could not find package faustbrian/bittrex at any version for your minimum-stability (stable). Check the package spelling or your minimum-stability